### PR TITLE
🎨 #38 escaping closure -> Swift Concurrency로 전환

### DIFF
--- a/Level1Kuiz/Model/QuizModel.swift
+++ b/Level1Kuiz/Model/QuizModel.swift
@@ -18,17 +18,13 @@ struct Quiz: Identifiable, Decodable {
     }
 }
 
+@MainActor
 class QuizExamplesModel: ObservableObject {
     @Published var data: [[Quiz.Answer]] = []
 
     init() {
-        QuizService().getQuizExamples { result in
-            switch result {
-            case .success(let data):
-                self.data = data
-            case .failure(let error):
-                print(error)
-            }
+        Task {
+            data = try await QuizService().fetchQuizExamples()
         }
     }
 }

--- a/Level1Kuiz/Network/HTTPClient.swift
+++ b/Level1Kuiz/Network/HTTPClient.swift
@@ -10,12 +10,12 @@ import Foundation
 
 class HTTPClient: ObservableObject {
     private let baseURL = "https://634a6d5f5df952851411457d.mockapi.io/kuiz"
-    
+
     func request<R: Decodable>(path: String, method: HTTPMethod, completeHandler: @escaping (Result<R, Error>) -> Void) {
         guard let url = URL(string: "\(baseURL)\(path)") else {
             fatalError(ServiceConstant.NOT_FOUND_URL)
         }
-        
+
         AF.request(try! URLRequest(url: url, method: method))
             .validate(statusCode: 200..<300)
             .responseDecodable(of: Response<R>.self) { response in
@@ -27,7 +27,7 @@ class HTTPClient: ObservableObject {
                 }
             }
     }
-    
+
     func request<R: Decodable>(
         type: R.Type,
         path: URLConvertible,
@@ -36,9 +36,9 @@ class HTTPClient: ObservableObject {
         guard let url = URL(string: "\(baseURL)\(path)") else {
             fatalError(ServiceConstant.NOT_FOUND_URL)
         }
-        
+
         let request = try URLRequest(url: url, method: method)
-        
+
         return try await AF.request(request)
             .validate(statusCode: 200..<300)
             .serializingDecodable(Response<R>.self)

--- a/Level1Kuiz/Network/HTTPClient.swift
+++ b/Level1Kuiz/Network/HTTPClient.swift
@@ -10,12 +10,12 @@ import Foundation
 
 class HTTPClient: ObservableObject {
     private let baseURL = "https://634a6d5f5df952851411457d.mockapi.io/kuiz"
-
+    
     func request<R: Decodable>(path: String, method: HTTPMethod, completeHandler: @escaping (Result<R, Error>) -> Void) {
         guard let url = URL(string: "\(baseURL)\(path)") else {
             fatalError(ServiceConstant.NOT_FOUND_URL)
         }
-
+        
         AF.request(try! URLRequest(url: url, method: method))
             .validate(statusCode: 200..<300)
             .responseDecodable(of: Response<R>.self) { response in
@@ -26,5 +26,23 @@ class HTTPClient: ObservableObject {
                     completeHandler(.failure(error))
                 }
             }
+    }
+    
+    func request<R: Decodable>(
+        type: R.Type,
+        path: URLConvertible,
+        method: HTTPMethod
+    ) async throws -> R {
+        guard let url = URL(string: "\(baseURL)\(path)") else {
+            fatalError(ServiceConstant.NOT_FOUND_URL)
+        }
+        
+        let request = try URLRequest(url: url, method: method)
+        
+        return try await AF.request(request)
+            .validate(statusCode: 200..<300)
+            .serializingDecodable(Response<R>.self)
+            .value
+            .data
     }
 }

--- a/Level1Kuiz/Network/Service/QuizService.swift
+++ b/Level1Kuiz/Network/Service/QuizService.swift
@@ -8,12 +8,6 @@
 import Foundation
 
 class QuizService {
-    func getQuizzes(completeHandler: @escaping (Result<[Quiz], Error>) -> Void) {
-        HTTPClient().request(path: "/quizzes", method: .get) { (result: Result<[Quiz], Error>) in
-            completeHandler(result)
-        }
-    }
-    
     func fetchQuizzes() async throws -> [Quiz] {
         try await HTTPClient().request(
             type: [Quiz].self,
@@ -22,9 +16,11 @@ class QuizService {
         )
     }
 
-    func getQuizExamples(completeHandler: @escaping (Result<[[Quiz.Answer]], Error>) -> Void) {
-        HTTPClient().request(path: "/examples", method: .get) { (result: Result<[[Quiz.Answer]], Error>) in
-            completeHandler(result)
-        }
+    func fetchQuizExamples() async throws -> [[Quiz.Answer]] {
+        try await HTTPClient().request(
+            type: [[Quiz.Answer]].self,
+            path: "/examples",
+            method: .get
+        )
     }
 }

--- a/Level1Kuiz/Network/Service/QuizService.swift
+++ b/Level1Kuiz/Network/Service/QuizService.swift
@@ -13,6 +13,14 @@ class QuizService {
             completeHandler(result)
         }
     }
+    
+    func fetchQuizzes() async throws -> [Quiz] {
+        try await HTTPClient().request(
+            type: [Quiz].self,
+            path: "/quizzes",
+            method: .get
+        )
+    }
 
     func getQuizExamples(completeHandler: @escaping (Result<[[Quiz.Answer]], Error>) -> Void) {
         HTTPClient().request(path: "/examples", method: .get) { (result: Result<[[Quiz.Answer]], Error>) in

--- a/Level1Kuiz/View/Quiz/QuizView.swift
+++ b/Level1Kuiz/View/Quiz/QuizView.swift
@@ -52,13 +52,9 @@ struct QuizView: View {
                         }
                     }
                     .onAppear {
-                        QuizService().getQuizzes { result in
-                            switch result {
-                            case .success(let data):
-                                quizzes = data.shuffled()
-                            case .failure(let error):
-                                print(error)
-                            }
+                        Task {
+                            let quizzes = try await QuizService().fetchQuizzes()
+                            self.quizzes = quizzes.shuffled()
                         }
                     }
                     .margin(top: 40)


### PR DESCRIPTION
`HTTPClient` 내에 Swift Concurrency를 이용한 request 메소드 오버로딩

`QuizService` 내에 `fetchQuizzes()` 메소드 정의 후 사용